### PR TITLE
Add backup forms of measurement for when encoders/string potentiometer fails mid match

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -321,7 +321,7 @@ public final class Constants {
   public static class WristConstants {
     public static final int MOTOR_ID = 25;
     public static final int TICKS_PER_REVOLUTION = 42;
-    public static final double GEAR_RATIO = 49;
+    public static final double GEAR_RATIO = 9 * 7 * 4;
     public static final int ENCODER_ID = 40;
   }
 

--- a/src/main/java/frc/robot/subsystems/ElevatorSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ElevatorSubsystem.java
@@ -130,10 +130,11 @@ public class ElevatorSubsystem extends ElevatorSubsystemBasePID {
     }
     return angle;
   }
+
   public double getBackupAngle() {
     return Math.asin(
             (elevatorMotorFront.getSelectedSensorPosition() / Constants.ArmConstants.ELEVATOR_GEARING)
-                    / Constants.ArmConstants.MOUNT_POINT_DISTANCE_ON_ARM);
+                    / Constants.ArmConstants.MOUNT_POINT_DISTANCE_ON_ARM) + backupAngleOffset;
   }
 
   /**

--- a/src/main/java/frc/robot/subsystems/WristSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/WristSubsystem.java
@@ -1,5 +1,6 @@
 package frc.robot.subsystems;
 
+import com.ctre.phoenix.ErrorCode;
 import com.ctre.phoenix.sensors.AbsoluteSensorRange;
 import com.ctre.phoenix.sensors.CANCoder;
 import com.revrobotics.CANSparkMax;
@@ -9,98 +10,132 @@ import edu.wpi.first.math.controller.ArmFeedforward;
 import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.networktables.NetworkTableEntry;
 import edu.wpi.first.networktables.NetworkTableInstance;
+import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants;
 
 public class WristSubsystem extends SubsystemBase {
-  private CANSparkMax wristMotor = new CANSparkMax(Constants.WristConstants.MOTOR_ID, CANSparkMax.MotorType.kBrushless);
-  private CANCoder wristEncoder = new CANCoder(Constants.WristConstants.ENCODER_ID);
-  // These constants are lower than they should be to prevent the wrist from going
-  // too far instantly
-  private PIDController wristPID = new PIDController(.1, 0, 0);
-  // These constants are calculated by Reca.lc, might need to be tuned slightly
-  // private ArmFeedforward wristFeedforward = new ArmFeedforward(0, 2.62, 0.48,
-  // 0.07);
-  private ArmFeedforward wristFeedforward = new ArmFeedforward(0, .2, .79, .04);
+    private CANSparkMax wristMotor = new CANSparkMax(Constants.WristConstants.MOTOR_ID, CANSparkMax.MotorType.kBrushless);
+    private CANCoder wristEncoder = new CANCoder(Constants.WristConstants.ENCODER_ID);
+    // These constants are lower than they should be to prevent the wrist from going
+    // too far instantly
+    private PIDController wristPID = new PIDController(.1, 0, 0);
+    // These constants are calculated by Reca.lc, might need to be tuned slightly
+    // private ArmFeedforward wristFeedforward = new ArmFeedforward(0, 2.62, 0.48,
+    // 0.07);
 
-  private NetworkTableEntry wristTargetAngleEntry = NetworkTableInstance.getDefault().getTable("Wrist")
-      .getEntry("targetAngle");
-  private NetworkTableEntry wristCurrentAngleEntry = NetworkTableInstance.getDefault().getTable("Wrist")
-      .getEntry("currentAngle");
-  private NetworkTableEntry wristVoltageEntry = NetworkTableInstance.getDefault().getTable("Wrist").getEntry("voltage");
-  private NetworkTableEntry wristCurrentEntry = NetworkTableInstance.getDefault().getTable("Wrist").getEntry("current");
-  private NetworkTableEntry wristTemperatureEntry = NetworkTableInstance.getDefault().getTable("Wrist")
-      .getEntry("temperature");
-  private NetworkTableEntry atSetpointEntry = NetworkTableInstance.getDefault().getTable("Wrist")
-      .getEntry("atSetpoint");
+    private double backupEncoderOffsetAngle = 0;
+    private ArmFeedforward wristFeedforward = new ArmFeedforward(0, .2, .79, .04);
 
-  private double setpoint = 0;
+    private NetworkTableEntry wristTargetAngleEntry = NetworkTableInstance.getDefault().getTable("Wrist")
+            .getEntry("targetAngle");
+    private NetworkTableEntry wristCurrentAngleEntry = NetworkTableInstance.getDefault().getTable("Wrist")
+            .getEntry("currentAngle");
+    private NetworkTableEntry wristBackupAngleEntry = NetworkTableInstance.getDefault().getTable("Wrist")
+            .getEntry("backupAngle");
+    private NetworkTableEntry wristVoltageEntry = NetworkTableInstance.getDefault().getTable("Wrist").getEntry("voltage");
+    private NetworkTableEntry wristCurrentEntry = NetworkTableInstance.getDefault().getTable("Wrist").getEntry("current");
+    private NetworkTableEntry wristTemperatureEntry = NetworkTableInstance.getDefault().getTable("Wrist")
+            .getEntry("temperature");
+    private NetworkTableEntry atSetpointEntry = NetworkTableInstance.getDefault().getTable("Wrist")
+            .getEntry("atSetpoint");
 
-  public WristSubsystem() {
-    wristEncoder.configAbsoluteSensorRange(AbsoluteSensorRange.Signed_PlusMinus180);
-    wristEncoder.configMagnetOffset(-50);
-    wristMotor.setIdleMode(IdleMode.kBrake);
-    wristMotor.setSmartCurrentLimit(30, 80);
-    // wristMotor.setSmartCurrentLimit(30, 40);
+    private double setpoint = 0;
+    private boolean isRunningBackup = false;
+    private boolean wasRunningBackup = false;
 
-  }
+    public WristSubsystem() {
+        wristEncoder.configAbsoluteSensorRange(AbsoluteSensorRange.Signed_PlusMinus180);
+        wristEncoder.configMagnetOffset(-50);
+        wristMotor.setIdleMode(IdleMode.kBrake);
+        wristMotor.setSmartCurrentLimit(30, 80);
+        // Set up backup encoder to default position. This will only be used if the CANCoder has issues mid match
+        backupEncoderOffsetAngle = wristEncoder.getAbsolutePosition();
+        if (wristEncoder.getLastError() != ErrorCode.OK) {
+            // Set the backup encoder to the starting position of the arm if there's a CANCoder issue on startup
+            // Also will send an alert to the driver station about there being an issue
+            System.err.println("Error reading value from wrist encoder. Defaulting to backup encoder with current angle of " + Constants.ArmSetpoints.STARTING_CONFIG.getWristAngle());
+            backupEncoderOffsetAngle = Constants.ArmSetpoints.STARTING_CONFIG.getWristAngle();
+        }
+    }
 
-  public void setTargetAngle(double angle) {
-    this.setpoint = angle;
-  }
+    public void setTargetAngle(double angle) {
+        this.setpoint = angle;
+    }
 
-  public double getTargetAngle() {
-    return this.setpoint;
-  }
+    public double getTargetAngle() {
+        return this.setpoint;
+    }
 
-  public double getAngle() {
-    // We need to find a set point to start the wrist at as a 0 point
-    // return wristMotor.getEncoder().getPosition() * 360
-    // / (Constants.WristConstants.TICKS_PER_REVOLUTION *
-    // Constants.WristConstants.GEAR_RATIO);
-    return wristEncoder.getAbsolutePosition();
-  }
+    public double getAngle() {
+        double angle = wristEncoder.getAbsolutePosition();
+        if (isRunningBackup || wristEncoder.getLastError() != ErrorCode.OK) {
+            // If there's an error reading from the CANCoder, use the backup encoder.
+            isRunningBackup = true;
+            angle = getBackupAngle();
+        }
+        return angle;
+    }
 
-  public void setVoltage(double voltage) {
-    wristMotor.setVoltage(voltage);
-  }
+    /**
+     * Returns the angle that the wrist is at using the built in encoder on the NEO550
+     * <p>
+     * Should only be used if a catastrophic failure occurs with the CANCoder
+     *
+     * @return The angle of the wrist in degrees
+     */
+    private double getBackupAngle() {
+        return wristMotor.getEncoder().getPosition() * 360
+                / (Constants.WristConstants.TICKS_PER_REVOLUTION *
+                Constants.WristConstants.GEAR_RATIO) + backupEncoderOffsetAngle;
+    }
 
-  public boolean atTarget() {
-    return Math.abs(getAngle() - setpoint) < 4;
-  }
+    public void setVoltage(double voltage) {
+        wristMotor.setVoltage(voltage);
+    }
 
-  public void run() {
-    double feedforward = wristFeedforward.calculate(Math.toRadians(setpoint), 0);
-    // + feedforward
-    // double output = feedforward;
-    double pid = wristPID.calculate(getAngle(), setpoint);
-    SmartDashboard.putNumber("WristPID", pid);
-    SmartDashboard.putNumber("WristFF", feedforward);
-    double output = feedforward + pid;
-    SmartDashboard.putNumber("WristOutput", output);
-    // System.out.println(feedforward);
-    // System.out.println("_________ " + output);
+    public boolean atTarget() {
+        return Math.abs(getAngle() - setpoint) < 4;
+    }
 
-    setVoltage(output);
-    wristCurrentAngleEntry.setDouble(getAngle());
-    wristTargetAngleEntry.setDouble(setpoint);
-    wristVoltageEntry.setDouble(wristMotor.getAppliedOutput());
-    wristCurrentEntry.setDouble(wristMotor.getOutputCurrent());
-    atSetpointEntry.setBoolean(atTarget());
-  }
+    public void run() {
+        double feedforward = wristFeedforward.calculate(Math.toRadians(setpoint), 0);
+        // + feedforward
+        // double output = feedforward;
+        double pid = wristPID.calculate(getAngle(), setpoint);
+        SmartDashboard.putNumber("WristPID", pid);
+        SmartDashboard.putNumber("WristFF", feedforward);
+        double output = feedforward + pid;
+        SmartDashboard.putNumber("WristOutput", output);
+        // System.out.println(feedforward);
+        // System.out.println("_________ " + output);
 
-  @Override
-  public void periodic() {
-    run();
-    // double feedforward = wristFeedforward.calculate(setpoint, 0);
-    // double output = wristPID.calculate(getAngle(), setpoint) + feedforward;
-    // // setVoltage(output);
-    // wristCurrentAngleEntry.setDouble(getAngle());
-    // wristTargetAngleEntry.setDouble(setpoint);
-    // wristVoltageEntry.setDouble(wristMotor.getAppliedOutput());
-    // wristCurrentEntry.setDouble(wristMotor.getOutputCurrent());
-    wristTemperatureEntry.setDouble(wristMotor.getMotorTemperature());
+        setVoltage(output);
+        wristCurrentAngleEntry.setDouble(getAngle());
+        wristBackupAngleEntry.setDouble(getBackupAngle());
+        wristTargetAngleEntry.setDouble(setpoint);
+        wristVoltageEntry.setDouble(wristMotor.getAppliedOutput());
+        wristCurrentEntry.setDouble(wristMotor.getOutputCurrent());
+        atSetpointEntry.setBoolean(atTarget());
+        if(isRunningBackup != wasRunningBackup) {
+            System.err.println("WristSubsystem is running backup encoder. This needs to be looked at ASAP");
+            wasRunningBackup = true;
+        }
+    }
 
-  }
+    @Override
+    public void periodic() {
+        run();
+        // double feedforward = wristFeedforward.calculate(setpoint, 0);
+        // double output = wristPID.calculate(getAngle(), setpoint) + feedforward;
+        // // setVoltage(output);
+//         wristCurrentAngleEntry.setDouble(getAngle());
+        // wristTargetAngleEntry.setDouble(setpoint);
+        // wristVoltageEntry.setDouble(wristMotor.getAppliedOutput());
+        // wristCurrentEntry.setDouble(wristMotor.getOutputCurrent());
+        wristTemperatureEntry.setDouble(wristMotor.getMotorTemperature());
+
+
+    }
 }


### PR DESCRIPTION
Adds backup forms of calculation to each of the major subsystems of the robot. Also provides single time logging to the console so we can see exactly when the failure occurred. 