### PR TITLE
Phoenix pro

### DIFF
--- a/src/main/java/frc/robot/swerve/ProSwerveModule.java
+++ b/src/main/java/frc/robot/swerve/ProSwerveModule.java
@@ -1,0 +1,124 @@
+package frc.robot.swerve;
+
+import com.ctre.phoenixpro.BaseStatusSignalValue;
+import com.ctre.phoenixpro.StatusSignalValue;
+import com.ctre.phoenixpro.configs.CANcoderConfiguration;
+import com.ctre.phoenixpro.configs.TalonFXConfiguration;
+import com.ctre.phoenixpro.controls.PositionVoltage;
+import com.ctre.phoenixpro.controls.VelocityTorqueCurrentFOC;
+import com.ctre.phoenixpro.hardware.CANcoder;
+import com.ctre.phoenixpro.hardware.TalonFX;
+import com.ctre.phoenixpro.signals.FeedbackSensorSourceValue;
+import com.ctre.phoenixpro.signals.InvertedValue;
+import com.ctre.phoenixpro.signals.NeutralModeValue;
+
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.kinematics.SwerveModulePosition;
+import edu.wpi.first.math.kinematics.SwerveModuleState;
+
+public class ProSwerveModule {
+    private TalonFX driveMotor;
+    private TalonFX steerMotor;
+    private CANcoder cancoder;
+
+    private StatusSignalValue<Double> drivePosition;
+    private StatusSignalValue<Double> driveVelocity;
+    private StatusSignalValue<Double> steerPosition;
+    private StatusSignalValue<Double> steerVelocity;
+    private BaseStatusSignalValue[] signals;
+    private double driveRotationsPerMeter = 0;
+
+    private PositionVoltage angleSetter = new PositionVoltage(0);
+    private VelocityTorqueCurrentFOC velocitySetter = new VelocityTorqueCurrentFOC(0);
+
+    private SwerveModulePosition internalState = new SwerveModulePosition();
+
+    public ProSwerveModule(SwerveModuleConstants constants) {
+      this(constants, "rio");
+    }
+
+    public ProSwerveModule(SwerveModuleConstants constants, String canbusName) {
+        this.driveMotor = new TalonFX(constants.DriveMotorId, canbusName);
+        this.steerMotor = new TalonFX(constants.SteerMotorId, canbusName);
+        this.cancoder = new CANcoder(constants.CANcoderId, canbusName);
+
+        TalonFXConfiguration talonConfigs = new TalonFXConfiguration();
+
+        talonConfigs.Slot0 = constants.DriveMotorGains;
+        talonConfigs.TorqueCurrent.PeakForwardTorqueCurrent = constants.SlipCurrent;
+        talonConfigs.TorqueCurrent.PeakReverseTorqueCurrent = constants.SlipCurrent;
+        driveMotor.getConfigurator().apply(talonConfigs);
+
+        talonConfigs.Slot0 = constants.SteerMotorGains;
+        talonConfigs.Feedback.FeedbackRemoteSensorID = constants.CANcoderId;
+        talonConfigs.Feedback.FeedbackSensorSource = FeedbackSensorSourceValue.FusedCANcoder;
+        talonConfigs.Feedback.RotorToSensorRatio = constants.SteerMotorGearRatio;
+        talonConfigs.ClosedLoopGeneral.ContinuousWrap = true;
+        talonConfigs.MotorOutput.Inverted = constants.SteerMotorReversed ? InvertedValue.Clockwise_Positive : InvertedValue.CounterClockwise_Positive;
+
+        steerMotor.getConfigurator().apply(talonConfigs);
+
+        CANcoderConfiguration cancoderConfigs = new CANcoderConfiguration();
+        cancoderConfigs.MagnetSensor.MagnetOffset = constants.CANcoderOffset;
+        cancoder.getConfigurator().apply(cancoderConfigs);
+
+        drivePosition = driveMotor.getPosition();
+        driveVelocity = driveMotor.getVelocity();
+        steerPosition = steerMotor.getPosition();
+        steerVelocity = steerMotor.getVelocity();
+
+        signals = new BaseStatusSignalValue[] {drivePosition, driveVelocity, steerPosition, steerVelocity};
+
+        double rotationsPerWheelRotation = constants.DriveMotorGearRatio;
+        double metersPerWheelRotation = constants.WheelRadius * 2 * Math.PI;
+        driveRotationsPerMeter = rotationsPerWheelRotation / metersPerWheelRotation;
+    }
+
+    public SwerveModulePosition getPosition() {
+        drivePosition.refresh();
+        driveVelocity.refresh();
+        steerPosition.refresh();
+        steerVelocity.refresh();
+
+        // Compensate for latency
+        double driveRotation = drivePosition.getValue() + (driveVelocity.getValue() * drivePosition.getTimestamp().getLatency());
+        double steerRotation = steerPosition.getValue() + (steerVelocity.getValue() * steerPosition.getTimestamp().getLatency());
+
+        internalState.distanceMeters = driveRotation / driveRotationsPerMeter;
+        internalState.angle = Rotation2d.fromRotations(steerRotation);
+
+        return internalState;
+    }
+
+    public void apply(SwerveModuleState state) {
+        SwerveModuleState optimizedModuleState = SwerveModuleState.optimize(state, internalState.angle);
+
+        double angleToSetDeg = optimizedModuleState.angle.getRotations();
+        steerMotor.setControl(angleSetter.withPosition(angleToSetDeg));
+
+        double velocityToSet = optimizedModuleState.speedMetersPerSecond * driveRotationsPerMeter;
+        driveMotor.setControl(velocitySetter.withVelocity(velocityToSet));
+    }
+
+    BaseStatusSignalValue[] getSignals() {
+        return signals;
+    }
+    
+    public void setNeutralMode(NeutralModeValue neutralMode) {
+      TalonFXConfiguration config = new TalonFXConfiguration();
+      config.MotorOutput.NeutralMode = neutralMode;
+      driveMotor.getConfigurator().apply(config);
+    }
+
+    public Rotation2d getSteerAngle() {
+      return internalState.angle;
+    }
+
+    public double getDriveVelocity() {
+      return driveVelocity.getValue();
+    }
+
+    public SwerveModuleState getState() {
+      return new SwerveModuleState(getDriveVelocity(), getSteerAngle());
+    }
+}

--- a/src/main/java/frc/robot/swerve/SwerveModuleConstants.java
+++ b/src/main/java/frc/robot/swerve/SwerveModuleConstants.java
@@ -1,0 +1,79 @@
+package frc.robot.swerve;
+
+import com.ctre.phoenixpro.configs.Slot0Configs;
+
+public class SwerveModuleConstants {
+    public int DriveMotorId = 0;
+    public int SteerMotorId = 0;
+    public int CANcoderId = 0;
+    public double CANcoderOffset = 0;
+    public double DriveMotorGearRatio = 0;
+    public double SteerMotorGearRatio = 0;
+    public double WheelRadius = 0;
+    public double LocationX = 0;
+    public double LocationY = 0;
+    public Slot0Configs DriveMotorGains = new Slot0Configs();
+    public Slot0Configs SteerMotorGains = new Slot0Configs();
+    public double SlipCurrent = 400;
+    public boolean SteerMotorReversed = false;
+    public SwerveModuleConstants withDriveMotorId(int id) {
+        DriveMotorId = id;
+        return this;
+    }
+    public SwerveModuleConstants withSteerMotorId(int id) {
+        SteerMotorId = id;
+        return this;
+    }
+    public SwerveModuleConstants withCANcoderId(int id) {
+        CANcoderId = id;
+        return this;
+    }
+    public SwerveModuleConstants withCANcoderOffset(double offset) {
+        CANcoderOffset = offset;
+        return this;
+    }
+    public SwerveModuleConstants withDriveMotorGearRatio(double ratio) {
+        DriveMotorGearRatio = ratio;
+        return this;
+    }
+    public SwerveModuleConstants withSteerMotorGearRatio(double ratio) {
+        SteerMotorGearRatio = ratio;
+        return this;
+    }
+    public SwerveModuleConstants withWheelRadius(double radius) {
+        WheelRadius = radius;
+        return this;
+    }
+    public SwerveModuleConstants withLocationX(double x) {
+        LocationX = x;
+        return this;
+    }
+    public SwerveModuleConstants withLocationY(double y) {
+        LocationY = y;
+        return this;
+    }
+    public SwerveModuleConstants withDriveMotorGains(Slot0Configs gains) {
+        DriveMotorGains = gains;
+        return this;
+    }
+    public SwerveModuleConstants withSteerMotorGains(Slot0Configs gains) {
+        SteerMotorGains = gains;
+        return this;
+    }
+    public SwerveModuleConstants withSlipCurrent(double current) {
+        SlipCurrent = current;
+        return this;
+    }
+    public SwerveModuleConstants withSteerMotorReversed(boolean reversed) {
+        SteerMotorReversed = reversed;
+        return this;
+    }
+
+    public SwerveModuleConstants fromModuleConfiguration(ModuleConfiguration config) {
+        return new SwerveModuleConstants()
+            .withDriveMotorGearRatio(config.getDriveReduction())
+            .withSteerMotorGearRatio(config.getSteerReduction())
+            .withWheelRadius(config.getWheelDiameter() / 2)
+            .withSteerMotorReversed(config.isSteerInverted());
+    }
+}

--- a/vendordeps/PhoenixProAnd5.json
+++ b/vendordeps/PhoenixProAnd5.json
@@ -1,13 +1,13 @@
 {
-    "fileName": "Phoenix.json",
-    "name": "CTRE-Phoenix (v5)",
-    "version": "5.30.4+23.0.11",
+    "fileName": "PhoenixProAnd5.json",
+    "name": "CTRE-Phoenix (Pro And v5)",
+    "version": "23.0.11",
     "frcYear": 2023,
-    "uuid": "ab676553-b602-441f-a38d-f1296eff6537",
+    "uuid": "3fcf3402-e646-4fa6-971e-18afe8173b1a",
     "mavenUrls": [
         "https://maven.ctr-electronics.com/release/"
     ],
-    "jsonUrl": "https://maven.ctr-electronics.com/release/com/ctre/phoenix/Phoenix5-frc2023-latest.json",
+    "jsonUrl": "https://maven.ctr-electronics.com/release/com/ctre/phoenixpro/PhoenixProAnd5-frc2023-latest.json",
     "javaDependencies": [
         {
             "groupId": "com.ctre.phoenix",
@@ -18,6 +18,11 @@
             "groupId": "com.ctre.phoenix",
             "artifactId": "wpiapi-java",
             "version": "5.30.4"
+        },
+        {
+            "groupId": "com.ctre.phoenixpro",
+            "artifactId": "wpiapi-java",
+            "version": "23.0.11"
         }
     ],
     "jniDependencies": [
@@ -409,6 +414,36 @@
             "artifactId": "simProPigeon2",
             "version": "23.0.11",
             "libName": "CTRE_SimProPigeon2",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        },
+        {
+            "groupId": "com.ctre.phoenixpro",
+            "artifactId": "wpiapi-cpp",
+            "version": "23.0.11",
+            "libName": "CTRE_PhoenixPro_WPI",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "linuxathena"
+            ],
+            "simMode": "hwsim"
+        },
+        {
+            "groupId": "com.ctre.phoenixpro.sim",
+            "artifactId": "wpiapi-cpp-sim",
+            "version": "23.0.11",
+            "libName": "CTRE_PhoenixPro_WPISim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
             "skipInvalidPlatforms": true,


### PR DESCRIPTION
Switches SwerveModule class to use phoenix pro syntax.

Should work mostly as a drop in replacement for the old swerve module syntax, with minor differences.